### PR TITLE
fix: sync::from_iterable

### DIFF
--- a/pypeln/sync/api/from_iterable.py
+++ b/pypeln/sync/api/from_iterable.py
@@ -7,8 +7,7 @@ from ..stage import Stage, ProcessFn
 from dataclasses import dataclass
 
 
-@dataclass
-class FromIterable(ProcessFn):
+class FromIterable(tp.NamedTuple):
     iterable: tp.Iterable
     maxsize: int
 


### PR DESCRIPTION
 TypeError: FromIterable() takes no arguments